### PR TITLE
refactor: JwtInterceptors Call method change

### DIFF
--- a/src/api/Auth.ts
+++ b/src/api/Auth.ts
@@ -17,7 +17,7 @@ import { tokenState } from '../app/recoilStore';
 import JwtInterceptors from './ApiController';
 
 const Auth = () => {
-  const instance = JwtInterceptors().instance;
+  const { instance } = JwtInterceptors();
   const setToken = useSetRecoilState(tokenState);
   const navigate = useNavigate();
 

--- a/src/api/Lecture.ts
+++ b/src/api/Lecture.ts
@@ -5,7 +5,7 @@ import JwtInterceptors from './ApiController';
 import { Review } from 'types/evaluate';
 
 const Lecture = () => {
-  const instance = JwtInterceptors().instance;
+  const { instance } = JwtInterceptors();
 
   // 메인페이지
   const main = async (lecture = 'modifiedDate', page = 1, majorType = '') => {

--- a/src/api/Major.ts
+++ b/src/api/Major.ts
@@ -3,7 +3,7 @@ import JwtInterceptors from './ApiController';
 import { VersionCheckSuccess } from 'types/common';
 
 const Major = () => {
-  const instance = JwtInterceptors().instance;
+  const { instance } = JwtInterceptors();
 
   // 버전체크
   const version = async () => {

--- a/src/api/Notice.ts
+++ b/src/api/Notice.ts
@@ -3,7 +3,7 @@ import type { NoticeItem, NoticeDetail } from '../types/notice';
 import { AxiosError } from 'axios';
 
 const Notices = () => {
-  const instance = JwtInterceptors().instance;
+  const { instance } = JwtInterceptors();
   //공지사항 조회 api
   const list = async (pageParam = 1) => {
     try {

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -18,7 +18,7 @@ import { Review } from 'types/evaluate';
 import { MyExam } from 'types/exam';
 
 const User = () => {
-  const instance = JwtInterceptors().instance;
+  const { instance } = JwtInterceptors();
   // 내 정보
   const info = async () => {
     try {


### PR DESCRIPTION
The approach to making API calls needs to be re-evaluated; refactoring will be necessary during the subsequent redesign phase.

roughly this way..?
```tsx
const post = <T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> => {
  return instance.post<T>(url, data, config);
};
```